### PR TITLE
 Obtener Órdenes según el Rol del Usuario

### DIFF
--- a/controller/orders-controller.js
+++ b/controller/orders-controller.js
@@ -2,9 +2,9 @@ const { ObjectId } = require('mongodb');
 const { mongoConnect, mongoClose } = require('../connect');
 const AppError = require('../errors/app-error');
 const OrderStatus = {
-  ENVIADA: 0,
-  PENDIENTE: 1,
-  COMPLETADA: 2,
+  PENDIENTE: 'PENDIENTE',
+  EN_PREPARACION: 'EN PREPARACIÓN',
+  LISTO_PARA_ENTREGAR: 'LISTO PARA ENTREGAR',
 };
 
 module.exports = {
@@ -53,12 +53,21 @@ module.exports = {
     }
   },
 
-  async getOrders() {
+  async getOrders(isChef) {
     try {
       const database = await mongoConnect();
       const orders = database.collection('orders');
 
-      const orderList = await orders.find().toArray();
+      let orderList;
+
+      // Si el usuario es un chef, obtener solo las órdenes en estado PENDIENTE o EN PREPARACIÓN
+      orderList = await orders.find({
+        $or: [
+          { status: OrderStatus.PENDIENTE },
+          { status: isChef ? OrderStatus.EN_PREPARACION : OrderStatus.LISTO_PARA_ENTREGAR }
+        ]
+      }).toArray();
+
       return orderList;
     } catch (error) {
       console.error('Error al obtener las órdenes:', error);

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -99,3 +99,33 @@ module.exports.requireWaiter = (req, resp, next) => (
       ? next(new AppError(403, 'No autorizado'))
       : next()
 );
+
+
+// Middleware para verificar si el usuario es un chef
+module.exports.isChef = (req) => {
+  const authorization = req.headers.authorization;
+  if (!authorization) {
+    return false; // El token no está presente
+  }
+  const [type, token] = authorization.split(' ');
+
+  try {
+    const decodedToken = jwt.verify(token, config.secret);
+    const userRole = decodedToken.rol;
+
+    // Verifica si el rol del usuario es "chef"
+    return userRole === 'chef';
+  } catch (error) {
+    return false; // El token no es válido
+  }
+};
+
+// Middleware para requerir que el usuario sea un chef
+module.exports.requireChef = (req, resp, next) => (
+  (!module.exports.isAuthenticated(req))
+    ? next(new AppError(401, 'No autenticado'))
+    : (!module.exports.isChef(req))
+      ? next(new AppError(403, 'No autorizado. Solo los chef pueden acceder.'))
+      : next()
+);
+

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -37,7 +37,7 @@ module.exports = (app, nextMain) => {
    */
   app.get('/orders', requireAuth, async (req, resp, next) => {
     try {
-      const orders = await ordersController.getOrders();
+      const orders = await ordersController.getOrders(isChef(req));
       resp
         .status(200)
         .json(orders);

--- a/routes/orders.js
+++ b/routes/orders.js
@@ -2,6 +2,8 @@ const {
   requireAuth,
   requireWaiter,
   isWaiter,
+  requireChef ,
+  isChef,
 } = require('../middleware/auth');
 const ordersController = require('../controller/orders-controller');
 
@@ -153,30 +155,29 @@ module.exports = (app, nextMain) => {
    * @code {401} si no hay cabecera de autenticación
    * @code {404} si la orderId con `orderId` indicado no existe
    */
-  app.put('/orders/:orderId', requireAuth, async (req, resp, next) => {
+  app.put('/orders/:orderId', requireChef, async (req, resp, next) => {
     try {
       const orderId = req.params.orderId;
       const updatedOrderData = req.body;
-
-      if (req.user.role !== 'waiter') {
-        const errorMessage = 'Acceso denegado. Solo los meseros pueden actualizar órdenes.';
+  
+      if (!isChef(req)) {
+        const errorMessage = 'Acceso denegado. Solo los chef pueden crear órdenes.';
         throw new Error(errorMessage);
       }
-
+  
       const result = await ordersController.updateOrder(orderId, updatedOrderData);
-
+  
       if (result.matchedCount === 0) {
         const errorMessage = 'Orden no encontrada.';
         throw new Error(errorMessage);
       }
-      resp
-        .status(200)
-        .json({ message: 'Orden actualizada con éxito' });
+  
+      resp.status(200).json({ message: 'Orden actualizada con éxito' });
     } catch (error) {
       next(error);
     }
   });
-
+  
   /**
    * @name DELETE /orders
    * @description Elimina una orden


### PR DESCRIPTION
La función getOrders se encarga de obtener la lista de órdenes de la base de datos, filtrando los resultados según el rol del usuario, ya sea un chef o un mesero. El objetivo es presentar únicamente las órdenes pertinentes a cada rol, mostrando las órdenes en estado "PENDIENTE" para los chefs, y las órdenes en estados "PENDIENTE" y "LISTO PARA ENTREGAR" para los meseros.